### PR TITLE
Change site lookup key for DBS backend to origin_site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ das2go
 
 Go implementation of DAS (Data Aggregation System for CMS)
 
+### Site query semantics
+
+DAS uses `site` for current data location information, as reported by
+Rucio/CRIC. Examples:
+
+```
+site dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM
+block dataset=/AlCaP0/Run2011A-ALCARECOEcalCalEtaCalib-v4/ALCARECO site=T1_US_FNAL*
+file dataset=/Cosmics/Run2010B-TkAlCosmics0T-v1/ALCARECO site=T1_US_FNAL_Buffer
+```
+
+DAS uses `origin_site` for DBS `origin_site_name`, i.e. original block
+placement. The direct DBS `origin_site=` filter is supported at block
+granularity with a dataset constraint:
+
+```
+origin_site dataset=/QCD_Pt_0to5_TuneZ2_7TeV_pythia6/wteo-qcd_tunez2_pt0to5_pythia_fall10_387-250136cb6ade55a0822a3f1b6b851d5a/USER instance=cms_dbs_ph_analysis_02
+block dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM origin_site=T2_US_Nebraska
+```
+
 ### Installation & Usage
 
 To compile the server you need a Go compiler, then perform the following:

--- a/das/das.go
+++ b/das/das.go
@@ -648,7 +648,7 @@ func ProcessLogic(dasquery dasql.DASQuery, maps []mongo.DASRecord, selectedServi
 					arr := strings.Split(furl, "/rses/")
 					furl = fmt.Sprintf("%s/rses/", arr[0])
 				}
-				if urn == "block4dataset" || urn == "block4dataset_site" || urn == "dataset4dataset_site" {
+				if urn == "block4dataset" || urn == "block4dataset_site" || urn == "dataset4dataset" || urn == "dataset4dataset_site" {
 					furl = fmt.Sprintf("%s/dids", furl)
 					if strings.Contains(furl, "#") {
 						furl = strings.Replace(furl, "#", "%23", -1)

--- a/das/das.go
+++ b/das/das.go
@@ -654,6 +654,9 @@ func ProcessLogic(dasquery dasql.DASQuery, maps []mongo.DASRecord, selectedServi
 						furl = strings.Replace(furl, "#", "%23", -1)
 					}
 				}
+				if urn == "block4block" {
+					furl = fmt.Sprintf("%s/datasets?deep=True", furl)
+				}
 				if urn == "rules4dataset" || urn == "rules4block" || urn == "rules4file" {
 					// adjust rest URL
 					furl = fmt.Sprintf("%s/rules", furl)

--- a/das/das.go
+++ b/das/das.go
@@ -868,9 +868,9 @@ func PostProcessing(dasquery dasql.DASQuery, data []mongo.DASRecord) []mongo.DAS
 	// defer function profiler
 	defer utils.MeasureTime("das/PostProcessing")()
 
-	// site4dataset use case
+	// origin_site4dataset use case
 	fields := dasquery.Fields
-	if utils.InList("site", fields) {
+	if utils.InList("origin_site", fields) {
 		var out []mongo.DASRecord
 		for _, r := range data {
 			var das mongo.DASRecord
@@ -892,7 +892,7 @@ func PostProcessing(dasquery dasql.DASQuery, data []mongo.DASRecord) []mongo.DAS
 			orig := false // original placement
 			if len(srvs) == 1 {
 				var recs []mongo.DASRecord
-				switch v := r["site"].(type) {
+				switch v := r["origin_site"].(type) {
 				case []interface{}:
 					for _, v := range v {
 						recs = append(recs, v.(mongo.DASRecord))

--- a/das/das.go
+++ b/das/das.go
@@ -648,7 +648,7 @@ func ProcessLogic(dasquery dasql.DASQuery, maps []mongo.DASRecord, selectedServi
 					arr := strings.Split(furl, "/rses/")
 					furl = fmt.Sprintf("%s/rses/", arr[0])
 				}
-				if urn == "block4dataset" || urn == "block4dataset_site" {
+				if urn == "block4dataset" || urn == "block4dataset_site" || urn == "dataset4dataset_site" {
 					furl = fmt.Sprintf("%s/dids", furl)
 					if strings.Contains(furl, "#") {
 						furl = strings.Replace(furl, "#", "%23", -1)

--- a/das/das.go
+++ b/das/das.go
@@ -648,7 +648,7 @@ func ProcessLogic(dasquery dasql.DASQuery, maps []mongo.DASRecord, selectedServi
 					arr := strings.Split(furl, "/rses/")
 					furl = fmt.Sprintf("%s/rses/", arr[0])
 				}
-				if urn == "block4dataset" {
+				if urn == "block4dataset" || urn == "block4dataset_site" {
 					furl = fmt.Sprintf("%s/dids", furl)
 					if strings.Contains(furl, "#") {
 						furl = strings.Replace(furl, "#", "%23", -1)

--- a/examples/block_queries.txt
+++ b/examples/block_queries.txt
@@ -3,11 +3,14 @@ block dataset=/ElectronHad/Run2011A-05Aug2011-v1/AOD
 block=/EG/Run2010A-Dec4ReReco_v1/AOD#f15ed71e-6491-4f73-a0e3-ac4248a6367d
 block file=/store/data/Run2010B/ZeroBias/RAW-RECO/v2/000/145/820/784478E3-52C2-DF11-A0CC-0018F3D0969A.root
 
-# find blocks for a given block/dataset and site name
+# find blocks for a given block/dataset and current location site name
 block block=/Cosmics/Run2010B-TkAlCosmics0T* site=T1_DE_KIT*
 block dataset=/AlCaP0/Run2011A-ALCARECOEcalCalEtaCalib-v4/ALCARECO site=T1_US_FNAL*
 
-# find blocks for a give site/SE
+# find blocks for a given dataset and DBS origin site storage element
+block dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM origin_site=T2_US_Nebraska
+
+# find blocks for a given current location site/SE
 block site=T3_US_Cornell
 block site=osg-se.cac.cornell.edu
 

--- a/examples/site_queries.txt
+++ b/examples/site_queries.txt
@@ -2,4 +2,4 @@
 site=T3_*
 site=T1_CH_CERN
 site dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM
-site dataset=/QCD_Pt_0to5_TuneZ2_7TeV_pythia6/wteo-qcd_tunez2_pt0to5_pythia_fall10_387-250136cb6ade55a0822a3f1b6b851d5a/USER instance=cms_dbs_ph_analysis_02
+origin_site dataset=/QCD_Pt_0to5_TuneZ2_7TeV_pythia6/wteo-qcd_tunez2_pt0to5_pythia_fall10_387-250136cb6ade55a0822a3f1b6b851d5a/USER instance=cms_dbs_ph_analysis_02

--- a/examples/site_queries.txt
+++ b/examples/site_queries.txt
@@ -1,5 +1,7 @@
-# find site information for various set of conditions
+# find current location site information for various conditions
 site=T3_*
 site=T1_CH_CERN
 site dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM
+
+# find DBS origin site information
 origin_site dataset=/QCD_Pt_0to5_TuneZ2_7TeV_pythia6/wteo-qcd_tunez2_pt0to5_pythia_fall10_387-250136cb6ade55a0822a3f1b6b851d5a/USER instance=cms_dbs_ph_analysis_02

--- a/maps/dbs3.yml
+++ b/maps/dbs3.yml
@@ -298,8 +298,9 @@ params : {
         "origin_site_name":"required",
         "dataset":"required",
 }
-lookup : dataset
+lookup : block
 das_map : [
+    {"das_key": "block", "rec_key":"block.name"},
     {"das_key": "dataset", "rec_key":"dataset.name", "api_arg":"dataset",
      "pattern": "/[\\w-]+/[\\w-]+/[A-Z-]+"},
     {"das_key": "origin_site", "rec_key":"origin_site.se", "api_arg":"origin_site_name",
@@ -871,7 +872,7 @@ das_map : [
 ]
 ---
 notations : [
-    {"api_output": "dataset", "rec_key": "name", "api": "blockorigin"},
+    {"api_output": "block_name", "rec_key": "name", "api": "blockorigin"},
     {"api_output": "creation_date", "rec_key":"creation_time", "api":""},
     {"api_output": "last_modification_date", "rec_key":"modification_time", "api":""},
     {"api_output": "create_by", "rec_key":"created_by", "api":""},

--- a/maps/dbs3.yml
+++ b/maps/dbs3.yml
@@ -302,7 +302,7 @@ lookup : dataset
 das_map : [
     {"das_key": "dataset", "rec_key":"dataset.name", "api_arg":"dataset",
      "pattern": "/[\\w-]+/[\\w-]+/[A-Z-]+"},
-    {"das_key": "site", "rec_key":"site.se", "api_arg":"origin_site_name",
+    {"das_key": "origin_site", "rec_key":"origin_site.se", "api_arg":"origin_site_name",
      "pattern":"([a-zA-Z0-9-_]+\\.){2}"},
 ]
 # NOTE: blocksummaries is a subset of filesummaries output, so we really don't

--- a/maps/dbs3.yml
+++ b/maps/dbs3.yml
@@ -248,9 +248,9 @@ params : {
         "dataset":"required",
         "dataset_access_type": "optional",
 }
-lookup : site
+lookup : origin_site
 das_map : [
-    {"das_key": "site", "rec_key":"site.name"},
+    {"das_key": "origin_site", "rec_key":"origin_site.name"},
     {"das_key": "dataset", "rec_key":"dataset.name", "api_arg":"dataset",
      "pattern": "/[\\w-]+/[\\w-]+/[A-Z-]+"},
 ]
@@ -263,9 +263,9 @@ params : {
         "block_name":"required",
         "dataset_access_type": "optional",
 }
-lookup : site
+lookup : origin_site
 das_map : [
-    {"das_key": "site", "rec_key":"site.name"},
+    {"das_key": "origin_site", "rec_key":"origin_site.name"},
     {"das_key": "block", "rec_key":"block.name", "api_arg":"block_name",
      "pattern": "/[\\w-]+/[\\w-]+/[A-Z-]+#[0-9a-zA-Z-]"},
 ]

--- a/maps/dbs3.yml
+++ b/maps/dbs3.yml
@@ -241,7 +241,7 @@ das_map : [
 ]
 ---
 urn: site4dataset
-url : "https://cmsweb.cern.ch:8443/dbs/prod/global/DBSReader/blocks/"
+url : "https://cmsweb.cern.ch:8443/dbs/prod/global/DBSReader/blocks"
 expire : 900
 params : {
         "detail":"True",
@@ -256,7 +256,7 @@ das_map : [
 ]
 ---
 urn: site4block
-url : "https://cmsweb.cern.ch:8443/dbs/prod/global/DBSReader/blocks/"
+url : "https://cmsweb.cern.ch:8443/dbs/prod/global/DBSReader/blocks"
 expire : 900
 params : {
         "detail":"True",
@@ -271,7 +271,7 @@ das_map : [
 ]
 ---
 urn: blocks
-url : "https://cmsweb.cern.ch:8443/dbs/prod/global/DBSReader/blocks/"
+url : "https://cmsweb.cern.ch:8443/dbs/prod/global/DBSReader/blocks"
 expire : 900
 params : {
         "block_name":"optional",
@@ -303,8 +303,8 @@ das_map : [
     {"das_key": "block", "rec_key":"block.name"},
     {"das_key": "dataset", "rec_key":"dataset.name", "api_arg":"dataset",
      "pattern": "/[\\w-]+/[\\w-]+/[A-Z-]+"},
-    {"das_key": "origin_site", "rec_key":"origin_site.se", "api_arg":"origin_site_name",
-     "pattern":"([a-zA-Z0-9-_]+\\.){2}"},
+    {"das_key": "origin_site", "rec_key":"origin_site.name", "api_arg":"origin_site_name",
+     "pattern":"^T[0-3]_"},
 ]
 # NOTE: blocksummaries is a subset of filesummaries output, so we really don't
 # need this API

--- a/maps/presentation.yml
+++ b/maps/presentation.yml
@@ -97,6 +97,7 @@ dataset : [
                  {"name":"Parents", "query":"parent dataset=%s"},
                  {"name":"Children", "query":"child dataset=%s"},
                  {"name":"Sites", "query":"site dataset=%s"},
+                 {"name":"Origin sites", "query":"origin_site dataset=%s"},
                  {"name":"Physics Groups", "query":"group dataset=%s"},
                 ],
          "description": "is a name of CMS dataset which represented as a path \
@@ -276,7 +277,7 @@ site : [
          "link":[
                  {"name":"Datasets", "query":"dataset site=%s"},
                 ],
-         "description": "is CMS site name used by Phedex and SiteDB systems",
+         "description": "is CMS current location site name used by Rucio/CRIC systems",
          "examples":[
          "site=T3_US_Cornell",
          ]
@@ -285,7 +286,7 @@ site : [
          "link":[
                  {"name":"Site", "query":"site=%s"},
                 ],
-         "description": "is a name of storage element used by Phedex/SiteDB systems",
+         "description": "is a current location storage element used by site information systems",
          "examples":[
          "site=osg-se.cac.cornell.edu",
          ]
@@ -309,14 +310,9 @@ site : [
         ],
 origin_site : [
         {"das":"origin_site.name", "ui":"Origin site name",
-         "description": "is DBS origin_site_name",
+         "description": "is DBS origin_site_name, i.e. the original block placement site",
          "examples":[
-         "origin_site dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM",
-         ]
-        },
-        {"das":"origin_site.se", "ui":"Origin storage element",
-         "examples":[
-         "block dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM origin_site=osg-se.cac.cornell.edu",
+         "origin_site dataset=/QCD_Pt_0to5_TuneZ2_7TeV_pythia6/wteo-qcd_tunez2_pt0to5_pythia_fall10_387-250136cb6ade55a0822a3f1b6b851d5a/USER instance=cms_dbs_ph_analysis_02",
          ]
         },
         {"das":"origin_site.kind", "ui":"Site type"},

--- a/maps/presentation.yml
+++ b/maps/presentation.yml
@@ -316,7 +316,7 @@ origin_site : [
         },
         {"das":"origin_site.se", "ui":"Origin storage element",
          "examples":[
-         "dataset origin_site=osg-se.cac.cornell.edu",
+         "block dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM origin_site=osg-se.cac.cornell.edu",
          ]
         },
         {"das":"origin_site.kind", "ui":"Site type"},

--- a/maps/presentation.yml
+++ b/maps/presentation.yml
@@ -307,6 +307,20 @@ site : [
         {"das":"error", "ui":"Error"},
         {"das":"reason", "ui":"Reason"},
         ],
+origin_site : [
+        {"das":"origin_site.name", "ui":"Origin site name",
+         "description": "is DBS origin_site_name",
+         "examples":[
+         "origin_site dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM",
+         ]
+        },
+        {"das":"origin_site.se", "ui":"Origin storage element",
+         "examples":[
+         "dataset origin_site=osg-se.cac.cornell.edu",
+         ]
+        },
+        {"das":"origin_site.kind", "ui":"Site type"},
+        ],
 monitor : [
         {"das":"monitor", "ui":"Monitor", "link":[],
          "description":"is a DAS keyword to find monitoring information about phedex for specific period of time",

--- a/maps/rucio.yml
+++ b/maps/rucio.yml
@@ -35,6 +35,19 @@ das_map : [
         {"das_key":"block", "rec_key":"block.name", "api_arg":"block"},
 ]
 ---
+
+urn : block4dataset_site
+url : "http://cms-rucio.cern.ch/dids/cms/"
+expire : 3600
+params : {"dataset":"required", "site":"required"}
+lookup : block
+das_map : [
+        {"das_key":"dataset", "rec_key":"dataset.name", "api_arg":"dataset"},
+        {"das_key":"site", "rec_key":"site.name", "api_arg":"site", "pattern":"^T[0-3]_"},
+        {"das_key":"block", "rec_key":"block.name", "api_arg":"block"},
+]
+
+---
 # we need ending slash since Rucio rules API requires /dids/cms//a/b/c pattern
 urn : rules4dataset
 url : "http://cms-rucio.cern.ch/dids/cms/"
@@ -128,17 +141,7 @@ das_map : [
         {"das_key":"file", "rec_key":"file.name", "pattern":"^T[0-3]_"},
 ]
 ---
-urn : block4dataset_site
-url : "http://cms-rucio.cern.ch/replicas/cms"
-expire : 3600
-params : {"dataset":"required", "site":"required"}
-lookup : block
-das_map : [
-        {"das_key":"dataset", "rec_key":"dataset.name", "api_arg":"dataset"},
-        {"das_key":"site", "rec_key":"site.name", "api_arg":"site", "pattern":"^T[0-3]_"},
-        {"das_key":"block", "rec_key":"block.name", "api_arg":"block"},
-]
----
+
 urn : rses
 url : "http://cms-rucio.cern.ch/rses"
 expire : 3600
@@ -166,4 +169,3 @@ notations : [
     {"api_output":"events", "rec_key":"nevents", "api":""},
     {"api_output":"lfn", "rec_key":"name", "api":""},
 ]
-

--- a/maps/rucio.yml
+++ b/maps/rucio.yml
@@ -48,6 +48,16 @@ das_map : [
 ]
 
 ---
+urn : block4block
+url : "http://cms-rucio.cern.ch/replicas/cms"
+expire : 3600
+params : {"block":"required"}
+lookup : block
+das_map : [
+        {"das_key":"block", "rec_key":"block.name", "api_arg":"block"},
+]
+
+---
 # we need ending slash since Rucio rules API requires /dids/cms//a/b/c pattern
 urn : rules4dataset
 url : "http://cms-rucio.cern.ch/dids/cms/"

--- a/maps/rucio.yml
+++ b/maps/rucio.yml
@@ -48,6 +48,16 @@ das_map : [
 ]
 
 ---
+urn : dataset4dataset
+url : "http://cms-rucio.cern.ch/dids/cms/"
+expire : 3600
+params : {"dataset":"required"}
+lookup : dataset
+das_map : [
+        {"das_key":"dataset", "rec_key":"dataset.name", "api_arg":"dataset"},
+]
+
+---
 urn : dataset4dataset_site
 url : "http://cms-rucio.cern.ch/dids/cms/"
 expire : 3600
@@ -148,6 +158,16 @@ lookup : file
 das_map : [
         {"das_key":"dataset", "rec_key":"dataset.name", "api_arg":"dataset"},
         {"das_key":"site", "rec_key":"site.name", "api_arg":"site", "pattern":"^T[0-3]_"},
+        {"das_key":"file", "rec_key":"file.name", "pattern":"^T[0-3]_"},
+]
+---
+urn : file4block
+url : "http://cms-rucio.cern.ch/replicas/cms"
+expire : 3600
+params : {"block":"required"}
+lookup : file
+das_map : [
+        {"das_key":"block", "rec_key":"block.name", "api_arg":"block"},
         {"das_key":"file", "rec_key":"file.name", "pattern":"^T[0-3]_"},
 ]
 ---

--- a/maps/rucio.yml
+++ b/maps/rucio.yml
@@ -48,6 +48,17 @@ das_map : [
 ]
 
 ---
+urn : dataset4dataset_site
+url : "http://cms-rucio.cern.ch/dids/cms/"
+expire : 3600
+params : {"dataset":"required", "site":"required"}
+lookup : dataset
+das_map : [
+        {"das_key":"dataset", "rec_key":"dataset.name", "api_arg":"dataset"},
+        {"das_key":"site", "rec_key":"site.name", "api_arg":"site", "pattern":"^T[0-3]_"},
+]
+
+---
 urn : block4block
 url : "http://cms-rucio.cern.ch/replicas/cms"
 expire : 3600

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"net/url"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/dmwm/das2go/dasql"
@@ -238,7 +237,6 @@ func rucioDatasetReplicaInfo(dataset, site string, records []mongo.DASRecord) (m
 	if bytes := rec["bytes"]; bytes != nil {
 		rec["size"] = bytes
 	}
-	normalizeRucioDatasetInfo(rec)
 	return rec, true
 }
 
@@ -309,33 +307,6 @@ func rucioNumericValue(value interface{}) (float64, bool) {
 		return num, err == nil
 	}
 	return 0, false
-}
-
-func normalizeRucioDatasetInfo(rec mongo.DASRecord) {
-	if states, ok := rec["states"].(mongo.DASRecord); ok {
-		var names []string
-		for name := range states {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		var records []mongo.DASRecord
-		for _, name := range names {
-			records = append(records, mongo.DASRecord{"name": name, "state": states[name]})
-		}
-		rec["states"] = records
-	}
-	if rses, ok := rec["rses"].(mongo.DASRecord); ok {
-		var names []string
-		for name := range rses {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		var records []mongo.DASRecord
-		for _, name := range names {
-			records = append(records, mongo.DASRecord{"name": name})
-		}
-		rec["rses"] = records
-	}
 }
 
 func rucioBlockReplicaInfo(block, site string) (mongo.DASRecord, bool) {

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -77,6 +77,18 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 		}
 		return out
 	}
+	if api == "dataset4dataset" {
+		if dataset, ok := datasetSpecName(specs["dataset"]); ok {
+			if info, ok := rucioBlockReplicaInfo(dataset, ""); ok {
+				rec := mongo.DASRecord{"name": dataset}
+				for k, v := range info {
+					rec[k] = v
+				}
+				out = append(out, rec)
+			}
+		}
+		return out
+	}
 	for _, rec := range records {
 		if api == "rses" {
 			if val, ok := specs["site"]; ok {
@@ -142,12 +154,6 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 					out = append(out, rec)
 				}
 			}
-		} else if api == "dataset4dataset" {
-			if rec["name"] != nil {
-				if dataset, ok := datasetSpecName(specs["dataset"]); ok {
-					rmap[dataset] = 1
-				}
-			}
 		} else if api == "dataset4dataset_site" {
 			if val, ok := specs["site"]; ok && rec["name"] != nil {
 				site := fmt.Sprintf("%s", val)
@@ -187,7 +193,7 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 			}
 		}
 	}
-	if api == "dataset4site" || api == "dataset4dataset" || api == "dataset4dataset_site" {
+	if api == "dataset4site" || api == "dataset4dataset_site" {
 		for d := range rmap {
 			rec := mongo.DASRecord{"name": d}
 			out = append(out, rec)

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -114,7 +114,10 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 			if val, ok := specs["site"]; ok && rec["name"] != nil {
 				site := fmt.Sprintf("%s", val)
 				block := rec["name"].(string)
-				if rucioBlockAtSite(block, site) {
+				if info, ok := rucioBlockReplicaInfo(block, site); ok {
+					for k, v := range info {
+						rec[k] = v
+					}
 					out = append(out, rec)
 				}
 			}
@@ -156,22 +159,45 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 	return out
 }
 
-func rucioBlockAtSite(block, site string) bool {
+func rucioBlockReplicaInfo(block, site string) (mongo.DASRecord, bool) {
 	furl := fmt.Sprintf("%s/replicas/cms/%s/datasets?deep=True", RucioUrl(), url.QueryEscape(block))
 	client := utils.HttpClient()
 	resp := utils.FetchResponse(client, furl, "")
 	if resp.Error != nil {
-		return false
+		return nil, false
 	}
+	info := make(mongo.DASRecord)
+	states := make(mongo.DASRecord)
+	rses := make(mongo.DASRecord)
+	var replicas []mongo.DASRecord
 	for _, rec := range loadRucioData("block4dataset_site", resp.Data) {
 		if rec["rse"] == nil {
 			continue
 		}
-		if rucioSiteMatch(site, rec["rse"].(string)) {
-			return true
+		rse := rec["rse"].(string)
+		if !rucioSiteMatch(site, rse) {
+			continue
 		}
+		replica := make(mongo.DASRecord)
+		for k, v := range rec {
+			replica[k] = v
+			if k != "name" && k != "scope" {
+				info[k] = v
+			}
+		}
+		if rec["state"] != nil {
+			states[rse] = rec["state"]
+		}
+		rses[rse] = []interface{}{}
+		replicas = append(replicas, replica)
 	}
-	return false
+	if len(replicas) == 0 {
+		return nil, false
+	}
+	info["states"] = states
+	info["rses"] = rses
+	info["replicas"] = replicas
+	return info, true
 }
 
 func rucioSiteMatch(site, rse string) bool {

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -145,12 +145,7 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 		} else if api == "dataset4dataset" {
 			if rec["name"] != nil {
 				if dataset, ok := datasetSpecName(specs["dataset"]); ok {
-					drec := rucioDatasetRecord(rmap, dataset)
-					block := fmt.Sprintf("%s", rec["name"])
-					if info, ok := rucioBlockReplicaInfo(block, ""); ok {
-						mergeRucioDatasetInfo(drec, info)
-					}
-					rmap[dataset] = drec
+					rmap[dataset] = 1
 				}
 			}
 		} else if api == "dataset4dataset_site" {
@@ -192,118 +187,13 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 			}
 		}
 	}
-	if api == "dataset4dataset" {
-		for _, val := range rmap {
-			switch rec := val.(type) {
-			case mongo.DASRecord:
-				out = append(out, rec)
-			case map[string]interface{}:
-				out = append(out, rec)
-			}
-		}
-	} else if api == "dataset4site" || api == "dataset4dataset_site" {
+	if api == "dataset4site" || api == "dataset4dataset" || api == "dataset4dataset_site" {
 		for d := range rmap {
 			rec := mongo.DASRecord{"name": d}
 			out = append(out, rec)
 		}
 	}
 	return out
-}
-
-func rucioDatasetRecord(rmap mongo.DASRecord, dataset string) mongo.DASRecord {
-	if val, ok := rmap[dataset]; ok {
-		if rec, ok := val.(mongo.DASRecord); ok {
-			return rec
-		}
-		if rec, ok := val.(map[string]interface{}); ok {
-			return rec
-		}
-	}
-	return mongo.DASRecord{
-		"name":     dataset,
-		"states":   mongo.DASRecord{},
-		"rses":     mongo.DASRecord{},
-		"replicas": []mongo.DASRecord{},
-	}
-}
-
-func mergeRucioDatasetInfo(dst mongo.DASRecord, info mongo.DASRecord) {
-	for _, key := range []string{"scope", "type"} {
-		if dst[key] == nil && info[key] != nil {
-			dst[key] = info[key]
-		}
-	}
-	for _, key := range []string{"bytes", "available_bytes", "length", "available_length"} {
-		if val, ok := numericValue(info[key]); ok {
-			dst[key] = numericSum(dst[key]) + val
-		}
-	}
-	if bytes, ok := dst["bytes"]; ok {
-		dst["size"] = bytes
-	}
-	mergeRecordMap(dst, info, "states")
-	mergeRecordMap(dst, info, "rses")
-	appendReplicas(dst, info)
-}
-
-func mergeRecordMap(dst mongo.DASRecord, src mongo.DASRecord, key string) {
-	dmap, ok := dst[key].(mongo.DASRecord)
-	if !ok {
-		dmap = mongo.DASRecord{}
-		dst[key] = dmap
-	}
-	switch smap := src[key].(type) {
-	case mongo.DASRecord:
-		for k, v := range smap {
-			dmap[k] = v
-		}
-	case map[string]interface{}:
-		for k, v := range smap {
-			dmap[k] = v
-		}
-	}
-}
-
-func appendReplicas(dst mongo.DASRecord, src mongo.DASRecord) {
-	var replicas []mongo.DASRecord
-	if val, ok := dst["replicas"].([]mongo.DASRecord); ok {
-		replicas = val
-	}
-	switch vals := src["replicas"].(type) {
-	case []mongo.DASRecord:
-		replicas = append(replicas, vals...)
-	case []interface{}:
-		for _, val := range vals {
-			if rec, ok := val.(mongo.DASRecord); ok {
-				replicas = append(replicas, rec)
-			} else if rec, ok := val.(map[string]interface{}); ok {
-				replicas = append(replicas, rec)
-			}
-		}
-	}
-	dst["replicas"] = replicas
-}
-
-func numericSum(value interface{}) float64 {
-	val, _ := numericValue(value)
-	return val
-}
-
-func numericValue(value interface{}) (float64, bool) {
-	switch val := value.(type) {
-	case float64:
-		return val, true
-	case float32:
-		return float64(val), true
-	case int:
-		return float64(val), true
-	case int64:
-		return float64(val), true
-	case json.Number:
-		num, err := val.Float64()
-		return num, err == nil
-	}
-	return 0, false
 }
 
 func datasetSpecName(value interface{}) (string, bool) {

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/dmwm/das2go/dasql"
@@ -237,6 +238,7 @@ func rucioDatasetReplicaInfo(dataset, site string, records []mongo.DASRecord) (m
 	if bytes := rec["bytes"]; bytes != nil {
 		rec["size"] = bytes
 	}
+	normalizeRucioDatasetInfo(rec)
 	return rec, true
 }
 
@@ -307,6 +309,33 @@ func rucioNumericValue(value interface{}) (float64, bool) {
 		return num, err == nil
 	}
 	return 0, false
+}
+
+func normalizeRucioDatasetInfo(rec mongo.DASRecord) {
+	if states, ok := rec["states"].(mongo.DASRecord); ok {
+		var names []string
+		for name := range states {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		var records []mongo.DASRecord
+		for _, name := range names {
+			records = append(records, mongo.DASRecord{"name": name, "state": states[name]})
+		}
+		rec["states"] = records
+	}
+	if rses, ok := rec["rses"].(mongo.DASRecord); ok {
+		var names []string
+		for name := range rses {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		var records []mongo.DASRecord
+		for _, name := range names {
+			records = append(records, mongo.DASRecord{"name": name})
+		}
+		rec["rses"] = records
+	}
 }
 
 func rucioBlockReplicaInfo(block, site string) (mongo.DASRecord, bool) {

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -122,6 +122,14 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 		} else if api == "rules4dataset" || api == "rules4block" || api == "rules4file" {
 			out = append(out, rec)
 		} else if api == "block4dataset" {
+			if rec["name"] != nil {
+				block := rec["name"].(string)
+				if info, ok := rucioBlockReplicaInfo(block, ""); ok {
+					for k, v := range info {
+						rec[k] = v
+					}
+				}
+			}
 			out = append(out, rec)
 		} else if api == "block4dataset_site" {
 			if val, ok := specs["site"]; ok && rec["name"] != nil {

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -142,6 +142,12 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 					out = append(out, rec)
 				}
 			}
+		} else if api == "dataset4dataset" {
+			if rec["name"] != nil {
+				if dataset, ok := specs["dataset"]; ok {
+					rmap[fmt.Sprintf("%s", dataset)] = 1
+				}
+			}
 		} else if api == "dataset4dataset_site" {
 			if val, ok := specs["site"]; ok && rec["name"] != nil {
 				site := fmt.Sprintf("%s", val)
@@ -181,7 +187,7 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 			}
 		}
 	}
-	if api == "dataset4site" || api == "dataset4dataset_site" {
+	if api == "dataset4site" || api == "dataset4dataset" || api == "dataset4dataset_site" {
 		for d := range rmap {
 			rec := mongo.DASRecord{"name": d}
 			out = append(out, rec)

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -64,6 +64,19 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 	records := loadRucioData(api, data)
 	specs := dasquery.Spec
 	rmap := make(mongo.DASRecord)
+	if api == "block4block" {
+		if val, ok := specs["block"]; ok {
+			block := fmt.Sprintf("%s", val)
+			if info, ok := rucioBlockReplicaInfoFromRecords(block, "", records); ok {
+				rec := mongo.DASRecord{"name": block}
+				for k, v := range info {
+					rec[k] = v
+				}
+				out = append(out, rec)
+			}
+		}
+		return out
+	}
 	for _, rec := range records {
 		if api == "rses" {
 			if val, ok := specs["site"]; ok {
@@ -166,11 +179,15 @@ func rucioBlockReplicaInfo(block, site string) (mongo.DASRecord, bool) {
 	if resp.Error != nil {
 		return nil, false
 	}
+	return rucioBlockReplicaInfoFromRecords(block, site, loadRucioData("block4dataset_site", resp.Data))
+}
+
+func rucioBlockReplicaInfoFromRecords(block, site string, records []mongo.DASRecord) (mongo.DASRecord, bool) {
 	info := make(mongo.DASRecord)
 	states := make(mongo.DASRecord)
 	rses := make(mongo.DASRecord)
 	var replicas []mongo.DASRecord
-	for _, rec := range loadRucioData("block4dataset_site", resp.Data) {
+	for _, rec := range records {
 		if rec["rse"] == nil {
 			continue
 		}
@@ -201,6 +218,9 @@ func rucioBlockReplicaInfo(block, site string) (mongo.DASRecord, bool) {
 }
 
 func rucioSiteMatch(site, rse string) bool {
+	if site == "" {
+		return true
+	}
 	if strings.Contains(site, "*") {
 		pat := "^" + strings.Replace(regexp.QuoteMeta(site), "\\*", ".*", -1) + "$"
 		matched, _ := regexp.MatchString(pat, rse)

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -142,6 +142,16 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 					out = append(out, rec)
 				}
 			}
+		} else if api == "dataset4dataset_site" {
+			if val, ok := specs["site"]; ok && rec["name"] != nil {
+				site := fmt.Sprintf("%s", val)
+				block := rec["name"].(string)
+				if _, ok := rucioBlockReplicaInfo(block, site); ok {
+					if dataset, ok := specs["dataset"]; ok {
+						rmap[fmt.Sprintf("%s", dataset)] = 1
+					}
+				}
+			}
 		} else if api == "full_record" {
 			out = append(out, rec)
 		} else if api == "file4dataset_site" || api == "file4block_site" {
@@ -171,7 +181,7 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 			}
 		}
 	}
-	if api == "dataset4site" {
+	if api == "dataset4site" || api == "dataset4dataset_site" {
 		for d := range rmap {
 			rec := mongo.DASRecord{"name": d}
 			out = append(out, rec)

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -144,8 +144,8 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 			}
 		} else if api == "dataset4dataset" {
 			if rec["name"] != nil {
-				if dataset, ok := specs["dataset"]; ok {
-					rmap[fmt.Sprintf("%s", dataset)] = 1
+				if dataset, ok := datasetSpecName(specs["dataset"]); ok {
+					rmap[dataset] = 1
 				}
 			}
 		} else if api == "dataset4dataset_site" {
@@ -153,8 +153,8 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 				site := fmt.Sprintf("%s", val)
 				block := rec["name"].(string)
 				if _, ok := rucioBlockReplicaInfo(block, site); ok {
-					if dataset, ok := specs["dataset"]; ok {
-						rmap[fmt.Sprintf("%s", dataset)] = 1
+					if dataset, ok := datasetSpecName(specs["dataset"]); ok {
+						rmap[dataset] = 1
 					}
 				}
 			}
@@ -194,6 +194,23 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 		}
 	}
 	return out
+}
+
+func datasetSpecName(value interface{}) (string, bool) {
+	switch v := value.(type) {
+	case string:
+		return v, v != ""
+	case []string:
+		if len(v) == 1 {
+			return v[0], v[0] != ""
+		}
+	case []interface{}:
+		if len(v) == 1 {
+			name, ok := v[0].(string)
+			return name, ok && name != ""
+		}
+	}
+	return "", false
 }
 
 func rucioBlockReplicaInfo(block, site string) (mongo.DASRecord, bool) {

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -109,6 +110,14 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 			out = append(out, rec)
 		} else if api == "block4dataset" {
 			out = append(out, rec)
+		} else if api == "block4dataset_site" {
+			if val, ok := specs["site"]; ok && rec["name"] != nil {
+				site := fmt.Sprintf("%s", val)
+				block := rec["name"].(string)
+				if rucioBlockAtSite(block, site) {
+					out = append(out, rec)
+				}
+			}
 		} else if api == "full_record" {
 			out = append(out, rec)
 		} else if api == "file4dataset_site" || api == "file4block_site" {
@@ -145,4 +154,31 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 		}
 	}
 	return out
+}
+
+func rucioBlockAtSite(block, site string) bool {
+	furl := fmt.Sprintf("%s/replicas/cms/%s/datasets?deep=True", RucioUrl(), url.QueryEscape(block))
+	client := utils.HttpClient()
+	resp := utils.FetchResponse(client, furl, "")
+	if resp.Error != nil {
+		return false
+	}
+	for _, rec := range loadRucioData("block4dataset_site", resp.Data) {
+		if rec["rse"] == nil {
+			continue
+		}
+		if rucioSiteMatch(site, rec["rse"].(string)) {
+			return true
+		}
+	}
+	return false
+}
+
+func rucioSiteMatch(site, rse string) bool {
+	if strings.Contains(site, "*") {
+		pat := "^" + strings.Replace(regexp.QuoteMeta(site), "\\*", ".*", -1) + "$"
+		matched, _ := regexp.MatchString(pat, rse)
+		return matched
+	}
+	return site == rse
 }

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -145,7 +145,12 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 		} else if api == "dataset4dataset" {
 			if rec["name"] != nil {
 				if dataset, ok := datasetSpecName(specs["dataset"]); ok {
-					rmap[dataset] = 1
+					drec := rucioDatasetRecord(rmap, dataset)
+					block := fmt.Sprintf("%s", rec["name"])
+					if info, ok := rucioBlockReplicaInfo(block, ""); ok {
+						mergeRucioDatasetInfo(drec, info)
+					}
+					rmap[dataset] = drec
 				}
 			}
 		} else if api == "dataset4dataset_site" {
@@ -187,13 +192,118 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 			}
 		}
 	}
-	if api == "dataset4site" || api == "dataset4dataset" || api == "dataset4dataset_site" {
+	if api == "dataset4dataset" {
+		for _, val := range rmap {
+			switch rec := val.(type) {
+			case mongo.DASRecord:
+				out = append(out, rec)
+			case map[string]interface{}:
+				out = append(out, rec)
+			}
+		}
+	} else if api == "dataset4site" || api == "dataset4dataset_site" {
 		for d := range rmap {
 			rec := mongo.DASRecord{"name": d}
 			out = append(out, rec)
 		}
 	}
 	return out
+}
+
+func rucioDatasetRecord(rmap mongo.DASRecord, dataset string) mongo.DASRecord {
+	if val, ok := rmap[dataset]; ok {
+		if rec, ok := val.(mongo.DASRecord); ok {
+			return rec
+		}
+		if rec, ok := val.(map[string]interface{}); ok {
+			return rec
+		}
+	}
+	return mongo.DASRecord{
+		"name":     dataset,
+		"states":   mongo.DASRecord{},
+		"rses":     mongo.DASRecord{},
+		"replicas": []mongo.DASRecord{},
+	}
+}
+
+func mergeRucioDatasetInfo(dst mongo.DASRecord, info mongo.DASRecord) {
+	for _, key := range []string{"scope", "type"} {
+		if dst[key] == nil && info[key] != nil {
+			dst[key] = info[key]
+		}
+	}
+	for _, key := range []string{"bytes", "available_bytes", "length", "available_length"} {
+		if val, ok := numericValue(info[key]); ok {
+			dst[key] = numericSum(dst[key]) + val
+		}
+	}
+	if bytes, ok := dst["bytes"]; ok {
+		dst["size"] = bytes
+	}
+	mergeRecordMap(dst, info, "states")
+	mergeRecordMap(dst, info, "rses")
+	appendReplicas(dst, info)
+}
+
+func mergeRecordMap(dst mongo.DASRecord, src mongo.DASRecord, key string) {
+	dmap, ok := dst[key].(mongo.DASRecord)
+	if !ok {
+		dmap = mongo.DASRecord{}
+		dst[key] = dmap
+	}
+	switch smap := src[key].(type) {
+	case mongo.DASRecord:
+		for k, v := range smap {
+			dmap[k] = v
+		}
+	case map[string]interface{}:
+		for k, v := range smap {
+			dmap[k] = v
+		}
+	}
+}
+
+func appendReplicas(dst mongo.DASRecord, src mongo.DASRecord) {
+	var replicas []mongo.DASRecord
+	if val, ok := dst["replicas"].([]mongo.DASRecord); ok {
+		replicas = val
+	}
+	switch vals := src["replicas"].(type) {
+	case []mongo.DASRecord:
+		replicas = append(replicas, vals...)
+	case []interface{}:
+		for _, val := range vals {
+			if rec, ok := val.(mongo.DASRecord); ok {
+				replicas = append(replicas, rec)
+			} else if rec, ok := val.(map[string]interface{}); ok {
+				replicas = append(replicas, rec)
+			}
+		}
+	}
+	dst["replicas"] = replicas
+}
+
+func numericSum(value interface{}) float64 {
+	val, _ := numericValue(value)
+	return val
+}
+
+func numericValue(value interface{}) (float64, bool) {
+	switch val := value.(type) {
+	case float64:
+		return val, true
+	case float32:
+		return float64(val), true
+	case int:
+		return float64(val), true
+	case int64:
+		return float64(val), true
+	case json.Number:
+		num, err := val.Float64()
+		return num, err == nil
+	}
+	return 0, false
 }
 
 func datasetSpecName(value interface{}) (string, bool) {

--- a/services/rucio.go
+++ b/services/rucio.go
@@ -77,13 +77,15 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 		}
 		return out
 	}
-	if api == "dataset4dataset" {
+	if api == "dataset4dataset" || api == "dataset4dataset_site" {
+		site := ""
+		if api == "dataset4dataset_site" {
+			if val, ok := specs["site"]; ok {
+				site = fmt.Sprintf("%s", val)
+			}
+		}
 		if dataset, ok := datasetSpecName(specs["dataset"]); ok {
-			if info, ok := rucioBlockReplicaInfo(dataset, ""); ok {
-				rec := mongo.DASRecord{"name": dataset}
-				for k, v := range info {
-					rec[k] = v
-				}
+			if rec, ok := rucioDatasetReplicaInfo(dataset, site, records); ok {
 				out = append(out, rec)
 			}
 		}
@@ -154,16 +156,6 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 					out = append(out, rec)
 				}
 			}
-		} else if api == "dataset4dataset_site" {
-			if val, ok := specs["site"]; ok && rec["name"] != nil {
-				site := fmt.Sprintf("%s", val)
-				block := rec["name"].(string)
-				if _, ok := rucioBlockReplicaInfo(block, site); ok {
-					if dataset, ok := datasetSpecName(specs["dataset"]); ok {
-						rmap[dataset] = 1
-					}
-				}
-			}
 		} else if api == "full_record" {
 			out = append(out, rec)
 		} else if api == "file4dataset_site" || api == "file4block_site" {
@@ -193,7 +185,7 @@ func RucioUnmarshal(dasquery dasql.DASQuery, api string, data []byte) []mongo.DA
 			}
 		}
 	}
-	if api == "dataset4site" || api == "dataset4dataset_site" {
+	if api == "dataset4site" {
 		for d := range rmap {
 			rec := mongo.DASRecord{"name": d}
 			out = append(out, rec)
@@ -217,6 +209,104 @@ func datasetSpecName(value interface{}) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func rucioDatasetReplicaInfo(dataset, site string, records []mongo.DASRecord) (mongo.DASRecord, bool) {
+	rec := mongo.DASRecord{
+		"name":   dataset,
+		"states": mongo.DASRecord{},
+		"rses":   mongo.DASRecord{},
+	}
+	nblocks := 0
+	for _, row := range records {
+		block, ok := row["name"].(string)
+		if !ok || block == "" {
+			continue
+		}
+		info, ok := rucioBlockReplicaInfo(block, site)
+		if !ok {
+			continue
+		}
+		nblocks += 1
+		mergeRucioDatasetReplicaInfo(rec, info)
+	}
+	if nblocks == 0 {
+		return nil, false
+	}
+	rec["nblocks"] = nblocks
+	if bytes := rec["bytes"]; bytes != nil {
+		rec["size"] = bytes
+	}
+	return rec, true
+}
+
+func mergeRucioDatasetReplicaInfo(dst mongo.DASRecord, src mongo.DASRecord) {
+	for _, key := range []string{"scope", "type"} {
+		if dst[key] == nil && src[key] != nil {
+			dst[key] = src[key]
+		}
+	}
+	for _, key := range []string{"bytes", "available_bytes", "length", "available_length"} {
+		if val, ok := rucioNumericValue(src[key]); ok {
+			cur, _ := rucioNumericValue(dst[key])
+			dst[key] = cur + val
+		}
+	}
+	mergeRucioRecordMap(dst, src, "states")
+	mergeRucioRSEs(dst, src)
+}
+
+func mergeRucioRecordMap(dst mongo.DASRecord, src mongo.DASRecord, key string) {
+	dmap, ok := dst[key].(mongo.DASRecord)
+	if !ok {
+		dmap = mongo.DASRecord{}
+		dst[key] = dmap
+	}
+	switch smap := src[key].(type) {
+	case mongo.DASRecord:
+		for k, v := range smap {
+			dmap[k] = v
+		}
+	case map[string]interface{}:
+		for k, v := range smap {
+			dmap[k] = v
+		}
+	}
+}
+
+func mergeRucioRSEs(dst mongo.DASRecord, src mongo.DASRecord) {
+	dmap, ok := dst["rses"].(mongo.DASRecord)
+	if !ok {
+		dmap = mongo.DASRecord{}
+		dst["rses"] = dmap
+	}
+	switch smap := src["rses"].(type) {
+	case mongo.DASRecord:
+		for rse := range smap {
+			dmap[rse] = []interface{}{}
+		}
+	case map[string]interface{}:
+		for rse := range smap {
+			dmap[rse] = []interface{}{}
+		}
+	}
+}
+
+func rucioNumericValue(value interface{}) (float64, bool) {
+	switch val := value.(type) {
+	case float64:
+		return val, true
+	case float32:
+		return float64(val), true
+	case int:
+		return float64(val), true
+	case int64:
+		return float64(val), true
+	case json.Number:
+		num, err := val.Float64()
+		return num, err == nil
+	}
+	return 0, false
 }
 
 func rucioBlockReplicaInfo(block, site string) (mongo.DASRecord, bool) {

--- a/templates/dbsql_vs_dasql.tmpl
+++ b/templates/dbsql_vs_dasql.tmpl
@@ -156,7 +156,7 @@ dataset dataset=/*/*RelVal*/* release=CMSSW_4_2_0
 
 <tr class="odd">
 <td colspan="2" style="">
-<b>Find site information for a given dataset/block/file/run</b>
+<b>Find current location site information for a given dataset/block/file/run</b>
 </td>
 </tr>
 <tr>
@@ -177,14 +177,18 @@ To perform such query you need to break it apart:<br/>
 dataset dataset=/Cosmics/*/* run=149011
 <br/>
 <em style="color:blue">
-2. Find site information
+2. Find current location site information
 </em>
 <br/>
 site dataset=/Cosmics/Run2010B-PromptReco-v2/DQM
+<br/>
+Find DBS origin-site information
+<br/>
+origin_site dataset=/QCD_Pt_0to5_TuneZ2_7TeV_pythia6/wteo-qcd_tunez2_pt0to5_pythia_fall10_387-250136cb6ade55a0822a3f1b6b851d5a/USER instance=cms_dbs_ph_analysis_02
 <br/><br/>
 <em style="color:blue">
 In DAS you need to break query apart and work with pieces:
-dataset knows about block/files, block knows about site, file knows about runs, etc.
+dataset knows about block/files, block knows about current location site, DBS block origin is exposed through origin_site, file knows about runs, etc.
 This approach scales better and allow faster query look-up.
 </em>
 </td>
@@ -247,7 +251,7 @@ N/A
 </td>
 <td>
 <em style="color:blue">
-Site information
+Current location site information
 </em><br/>
 site=T1_CH_CERN
 <br/>

--- a/templates/faq.tmpl
+++ b/templates/faq.tmpl
@@ -672,8 +672,8 @@ site dataset=/Cosmics/Run2010B-TkAlCosmics0T-v1/ALCARECO
 # find site for PRODUCTION dataset
 site dataset=/tt1j_mT_70-alpgen/CMSSW_1_5_2-CSA07-2211/GEN-SIM-DIGI-RECO
 
-# find site info of dataset from local instance (should yield DBS3 origin_site_name)
-site dataset=/SingleLongLivedFlatPt_M_1000_CTau350_cfi_py_GEN_SIM/zhenhu-SingleLongLivedFlatPt_M_1000_CTau350_cfi_py_GEN_SIM-6db2d900755bd45dd25b8bfc112dfb1f/USER instance=prod/phys03
+# find origin site info of dataset from local instance (should yield DBS3 origin_site_name)
+origin_site dataset=/SingleLongLivedFlatPt_M_1000_CTau350_cfi_py_GEN_SIM/zhenhu-SingleLongLivedFlatPt_M_1000_CTau350_cfi_py_GEN_SIM-6db2d900755bd45dd25b8bfc112dfb1f/USER instance=prod/phys03
 
 # summary queries
 summary dataset=/Cosmics/Run2010B-TkAlCosmics0T-Dec22ReReco_v2/ALCARECO run=149011
@@ -715,4 +715,3 @@ release file=/store/data/Run2011A/ElectronHad/AOD/05Aug2011-v1/0000/00157DBB-0AC
 </div> <!-- end of class="page" -->
 
 <!-- end of faq.tmpl -->
-

--- a/templates/faq.tmpl
+++ b/templates/faq.tmpl
@@ -443,7 +443,7 @@ this section
 <p>
 Here is an incomplete list of queries supported in DAS
 <br/>
-Queries to get Site information
+Queries to get current location site information
 </p>
 <div class="example">
 <pre>
@@ -451,6 +451,17 @@ T1_CH_CERN
 site=T1_CH_CERN
 site=T1_*
 site=T1_* | grep site.name, site.se
+</pre>
+</div>
+<p>
+DBS origin-site information is exposed as <em>origin_site</em>. The
+<em>origin_site=</em> filter is a direct DBS block-level filter and requires a
+dataset condition.
+</p>
+<div class="example">
+<pre>
+origin_site dataset=/QCD_Pt_0to5_TuneZ2_7TeV_pythia6/wteo-qcd_tunez2_pt0to5_pythia_fall10_387-250136cb6ade55a0822a3f1b6b851d5a/USER instance=cms_dbs_ph_analysis_02
+block dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM origin_site=T2_US_Nebraska
 </pre>
 </div>
 
@@ -661,18 +672,23 @@ run between [148124,148126]
 run date = 20110320
 run date between [20101001, 20101002]
 
-# site queries
+# current location site queries
 site=T2_*
 site=T3_*
 site=T1_CH_CERN
 site dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM
-site dataset=/QCD_Pt_0to5_TuneZ2_7TeV_pythia6/wteo-qcd_tunez2_pt0to5_pythia_fall10_387-250136cb6ade55a0822a3f1b6b851d5a/USER instance=cms_dbs_ph_analysis_02
 site dataset=/Cosmics/Run2010B-TkAlCosmics0T-v1/ALCARECO
 
 # find site for PRODUCTION dataset
 site dataset=/tt1j_mT_70-alpgen/CMSSW_1_5_2-CSA07-2211/GEN-SIM-DIGI-RECO
 
-# find origin site info of dataset from local instance (should yield DBS3 origin_site_name)
+# origin site queries from DBS origin_site_name
+origin_site dataset=/QCD_Pt_0to5_TuneZ2_7TeV_pythia6/wteo-qcd_tunez2_pt0to5_pythia_fall10_387-250136cb6ade55a0822a3f1b6b851d5a/USER instance=cms_dbs_ph_analysis_02
+
+# direct origin_site filter is supported at block granularity
+block dataset=/WJets_matchingup_7TeV-madgraph/Summer10-START36_V10_FastSim-v3/DQM origin_site=T2_US_Nebraska
+
+# find origin site info of dataset from local instance
 origin_site dataset=/SingleLongLivedFlatPt_M_1000_CTau350_cfi_py_GEN_SIM/zhenhu-SingleLongLivedFlatPt_M_1000_CTau350_cfi_py_GEN_SIM-6db2d900755bd45dd25b8bfc112dfb1f/USER instance=prod/phys03
 
 # summary queries

--- a/web/utils.go
+++ b/web/utils.go
@@ -487,6 +487,12 @@ func PresentData(path string, dasquery dasql.DASQuery, data []mongo.DASRecord, p
 					log.Printf("WARNING: unsupported type of record %+v, key=%s\n", pmap, key)
 				}
 			}
+			if len(uiRows) == 0 && key == "origin_site" {
+				uiRows = []interface{}{
+					mongo.DASRecord{"das": "origin_site.name", "ui": "Origin site name"},
+					mongo.DASRecord{"das": "origin_site.kind", "ui": "Site type"},
+				}
+			}
 			for idx, elem := range records {
 				if elem == nil {
 					continue

--- a/web/utils.go
+++ b/web/utils.go
@@ -470,6 +470,10 @@ func PresentData(path string, dasquery dasql.DASQuery, data []mongo.DASRecord, p
 			switch r := item[key].(type) {
 			case []interface{}:
 				records = r
+			case []mongo.DASRecord:
+				for _, rec := range r {
+					records = append(records, rec)
+				}
 			case mongo.DASRecord:
 				records = append(records, r)
 			}


### PR DESCRIPTION
Fixes #70

#### Status

In testing.

#### Description

This PR clarifies and separates the DAS semantics of `site` across DBS- and Rucio-backed query paths.

The current behavior allows the same user-facing `site` lookup/filter to represent different backend concepts depending on the selected query mapping:

* in DBS-backed paths, the site-like information represents the data origin / original placement;
* in Rucio-backed paths, `site` represents the current data location / replica presence.

This creates ambiguous behavior for users and can lead to inconsistent results across dataset-, block-, and file-level queries.

This PR changes the query semantics so that:

* `site` is preserved for the Rucio-backed meaning: current data location / replica presence;
* DBS-origin semantics are split into a separate origin-site concept, e.g. `origin_site`, instead of being exposed through the same `site` key;
* `site=` filters are adjusted to follow the same separation, so `site=<X>` consistently means current Rucio location/presence;
* DBS origin filtering is routed through the explicit origin-site key instead of overloading `site=`;
* related maps, service handling, and documentation/tests are updated accordingly.

The intended result is that the meaning of the user-facing filter no longer depends on whether the query is resolved through DBS or Rucio, nor on whether the query is performed at dataset, block, or file granularity.

#### Is it backward compatible (if not, which system it affects?)

Not fully backward compatible.

Queries that previously relied on DBS-origin behavior through `site=` will need to use the new explicit origin-site query/filter key. This affects DAS users and integrations that interpreted `site=` as DBS data origin/original placement.

The intended compatibility-preserving behavior is that `site=` continues to work for Rucio-backed current-location queries.

#### Related PRs

* DASMaps upgrade: https://github.com/dmwm/DASMaps/pull/47
* `dasgoclient` version upgrade to be linked to the latest `das2go` tag: https://github.com/dmwm/dasgoclient/commit/7f6d7f5e779c6770bd2914f078d56534613f6483
* `dasgoclient` version ramp up at `CMSSW`: https://github.com/cms-sw/cmsdist/pull/10677
#### External dependencies / deployment changes

No new external dependencies are expected.

Deployment should include updated DAS maps and documentation together with the code change, so that the new `site` versus `origin-site` semantics are exposed consistently in production.

